### PR TITLE
TraceEventLogger ignores the line feed and new line characters. Bonus…

### DIFF
--- a/src/SenseNet.Tools/Diagnostics/SnLog.cs
+++ b/src/SenseNet.Tools/Diagnostics/SnLog.cs
@@ -2,6 +2,8 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
 using SenseNet.Tools;
 
 namespace SenseNet.Diagnostics
@@ -189,6 +191,11 @@ namespace SenseNet.Diagnostics
                 var data = e.Data;
                 foreach (var key in data.Keys)
                     props.Add(epath + key, data[key]);
+
+                var rtle = e as ReflectionTypeLoadException;
+                if (rtle != null)
+                    props.Add("Types", string.Join(", ", rtle.Types.Select(x => x.FullName)));
+
                 e = e.InnerException;
             }
             return props;

--- a/src/SenseNet.Tools/Diagnostics/TraceEventLogger.cs
+++ b/src/SenseNet.Tools/Diagnostics/TraceEventLogger.cs
@@ -30,7 +30,7 @@ namespace SenseNet.Diagnostics
                     ? string.Empty
                     : string.Join(", ", properties.Select(p => string.Concat(p.Key, ":", p.Value))))}";
 
-            Write(msg);
+            Write(msg.Replace('\r', '\n').Replace("\n\n", "\n").Replace("\n", " | "));
         }
 
         /// <summary>


### PR DESCRIPTION
…: relevant type names are included into the ReflectionTypeLoadException trace record.