### PR TITLE
Added detailed log in case of ReflectionTypeLoadException

### DIFF
--- a/src/SenseNet.Tools/Tools/TypeResolver.cs
+++ b/src/SenseNet.Tools/Tools/TypeResolver.cs
@@ -247,6 +247,18 @@ namespace SenseNet.Tools
                                 list.AddRange(asm.GetTypes().Where(type =>
                                     type.GetInterfaces().Any(interf => interf == interfaceType)));
                             }
+                            catch (ReflectionTypeLoadException rtle)
+                            {
+                                SnLog.WriteError(rtle.ToString(), properties: new Dictionary<string, object> { { "Assembly", asm.FullName } });
+
+                                // Logging each exception
+                                foreach (var exc in rtle.LoaderExceptions)
+                                {
+                                    SnLog.WriteError(exc);
+                                }
+
+                                throw;
+                            }
                             catch (Exception e)
                             {
                                 if (!IgnorableException(e))


### PR DESCRIPTION
Added the detailed log for ReflectionTypeLoadException in another method for TypeResolver.

One another thing. I think this logging avoids the  'IgnorableException' method call because it catches the error before it. Please check it if it's necessary because if it is then this solution is not good.