### PR TITLE
TypeResolver: log ReflectionTypeLoadException with more details

### DIFF
--- a/src/SenseNet.Tools.Tests/SenseNet.Tools.Tests.csproj
+++ b/src/SenseNet.Tools.Tests/SenseNet.Tools.Tests.csproj
@@ -65,6 +65,7 @@
     <Compile Include="SnTraceTestClass.cs" />
     <Compile Include="SnTraceTests.cs" />
     <Compile Include="SnLogTests.cs" />
+    <Compile Include="TypeResolverTests.cs" />
     <Compile Include="UtilityTests.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/SenseNet.Tools.Tests/TypeResolverTests.cs
+++ b/src/SenseNet.Tools.Tests/TypeResolverTests.cs
@@ -1,0 +1,65 @@
+﻿using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace SenseNet.Tools.Tests
+{
+    #region Test classes
+
+    internal interface ITestInterface
+    {
+    }
+
+    internal class BaseClass
+    {
+    }
+
+    internal class DerivedClass1 : BaseClass
+    {
+    }
+    internal class DerivedClass11 : DerivedClass1, ITestInterface
+    {
+    }
+    internal class IndependentClass1 : ITestInterface
+    {
+    }
+
+    #endregion
+
+    [TestClass]
+    public class TypeResolverTests
+    {
+        [TestMethod]
+        public void TypeResolver_GetType()
+        {
+            var t = TypeResolver.GetType("SenseNet.Tools.TypeResolver");
+            Assert.IsNotNull(t);
+        }
+
+        [TestMethod]
+        public void TypeResolver_GetTypesByBaseType()
+        {
+            var types = TypeResolver.GetTypesByBaseType(typeof(BaseClass));
+
+            Assert.AreEqual(2, types.Length);
+            Assert.IsTrue(types.Any(t => t.Name == "DerivedClass1"));
+            Assert.IsTrue(types.Any(t => t.Name == "DerivedClass11"));
+        }
+        [TestMethod]
+        public void TypeResolver_GetTypesByInterface()
+        {
+            var types = TypeResolver.GetTypesByInterface(typeof(ITestInterface));
+
+            Assert.AreEqual(2, types.Length);
+            Assert.IsTrue(types.Any(t => t.Name == "DerivedClass11"));
+            Assert.IsTrue(types.Any(t => t.Name == "IndependentClass1"));
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(TypeNotFoundException))]
+        public void TypeResolver_Error_GetType()
+        {
+            var t = TypeResolver.GetType("UnknownType");
+            Assert.IsNotNull(t);
+        }
+    }
+}

--- a/src/SenseNet.Tools/Tools/TypeResolver.cs
+++ b/src/SenseNet.Tools/Tools/TypeResolver.cs
@@ -247,6 +247,18 @@ namespace SenseNet.Tools
                                 list.AddRange(asm.GetTypes().Where(type =>
                                     type.GetInterfaces().Any(interf => interf == interfaceType)));
                             }
+                            catch (ReflectionTypeLoadException rtle)
+                            {
+                                SnLog.WriteError(rtle.ToString(), properties: new Dictionary<string, object> { { "Assembly", asm.FullName } });
+
+                                // Logging each exception
+                                foreach (var exc in rtle.LoaderExceptions)
+                                {
+                                    SnLog.WriteError(exc);
+                                }
+
+                                throw;
+                            }
                             catch (Exception e)
                             {
                                 if (!IgnorableException(e))


### PR DESCRIPTION
Log inner LoaderExceptions in case of a ReflectionTypeLoadException, when loading types by base type or interface using the TypeResolver API.

This will also close SenseNet/sn-tools/pull/7