### PR TITLE
Feature/trace asm loading

### DIFF
--- a/src/SenseNet.Tools/Tools/TypeResolver.cs
+++ b/src/SenseNet.Tools/Tools/TypeResolver.cs
@@ -190,17 +190,19 @@ namespace SenseNet.Tools
                 {
                     try
                     {
-                        var asmName = AssemblyName.GetAssemblyName(dllPath).Name;
-                        if (!assemblyNames.Contains(asmName))
+                        var asmName = AssemblyName.GetAssemblyName(dllPath);
+                        var asmFullName = asmName.FullName;
+                        var asmNameName = asmName.Name;
+                        if (!assemblyNames.Contains(asmNameName))
                         {
                             Assembly.LoadFrom(dllPath);
-                            assemblyNames.Add(asmName);
+                            assemblyNames.Add(asmNameName);
                             loaded.Add(Path.GetFileName(dllPath));
-                            SnTrace.Repository.Write("Loaded: {0}, {1}", asmName, dllPath);
+                            SnTrace.Repository.Write("ASM Loaded: {0}, {1}", asmFullName, dllPath);
                         }
                         else
                         {
-                            SnTrace.Repository.Write("Skipped: {0}, {1}", asmName, dllPath);
+                            SnTrace.Repository.Write("ASM Skipped: {0}, {1}", asmFullName, dllPath);
                         }
                     }
                     catch (BadImageFormatException e) //logged


### PR DESCRIPTION
Please review and manage this branch. The trace of the system start is extended by assembly loading information that is something like this:
```
... Repository ... Op:2 Start ... Loading assemblies from: D:\dev\github\sensenet\src\Tests\SenseNet.ContentRepository.Tests\bin\Debug
... Repository ...                ASM Loaded: asm1, Version=4.1.6.0, Culture=neutral, PublicKeyToken=01234, D:\dev\github\...\asm1.dll
... Repository ...                ASM Skipped: asm2, Version=4.1.6.0, Culture=neutral, PublicKeyToken=01234, D:\dev\github\...\asm2.dll
```