### PR TITLE
Avoid IO errors.

### DIFF
--- a/src/SenseNet.Tools.Tests/SnTraceTests.cs
+++ b/src/SenseNet.Tools.Tests/SnTraceTests.cs
@@ -21,6 +21,38 @@ namespace SenseNet.Tools.Tests
             Assert.IsTrue(msg.Contains(expectedSubstring));
         }
 
+        //[TestMethod]
+        //public void SnTrace_InfiniteWriting()
+        //{
+        //    // WARNING
+        //    // This method causes an infinite loop. Designed for a manual test.
+        //    // Before the fix this test threw an IOException with a similar message:
+        //    // "The process cannot access the file '...' because it is being used by another process."
+        //    //
+        //    // The manual test steps:
+        //    //   1 - PREPARATION
+        //    //     - Uncomment the whole test method.
+        //    //     - Start only this test.
+        //    //     - Search the log file in the bin\Debug\App_Data\DetailedLog directory
+        //    //       (example name: detailedlog_20200116-052425-7334Z.log)
+        //    //   2 - TEST ACTION
+        //    //     - Open this file a file-blocker application (e.g. Microsoft Word)
+        //    //   3 - ASSERT
+        //    //     - The test runs continuously and a new log file created.
+        //    //   4 - COMPLETION
+        //    //     - Stop the running test.
+        //    //     - Comment out the whole test method.
+
+        //    CleanupAndEnableAll();
+
+        //    while (true)
+        //    {
+        //        SnTrace.Write("test-line");
+        //        SnTrace.Flush();
+        //        System.Threading.Thread.Sleep(1000);
+        //    }
+        //}
+
         [TestMethod]
         public void SnTrace_Write2lines()
         {


### PR DESCRIPTION
Please check, merge and delete this branch.

Changes:
- If the currently used trace file has been locked by another process, a new log file is created immediately.
- The trace file name is extended with four fraction digit of the seconds ("yyyyMMdd-HHmmss" -> "yyyyMMdd-HHmmss-ffff"). This reduces the file name collision.