### PR TITLE
Feature/accessor inheritance

### DIFF
--- a/src/SenseNet.Tools.Tests/AccessorTests.cs
+++ b/src/SenseNet.Tools.Tests/AccessorTests.cs
@@ -100,40 +100,40 @@ namespace SenseNet.Tools.Tests
         [TestMethod]
         public void Accessor_Private_Type_Field()
         {
-            var objAcc = new TypeAccessor(typeof(AccessorTestObject));
+            var typeAcc = new TypeAccessor(typeof(AccessorTestObject));
 
-            var origValue = (int)objAcc.GetStaticField("_staticPrivateField");
-            objAcc.SetStaticField("_staticPrivateField", origValue + 1);
-            var actualValue = (int)objAcc.GetStaticField("_staticPrivateField");
+            var origValue = (int)typeAcc.GetStaticField("_staticPrivateField");
+            typeAcc.SetStaticField("_staticPrivateField", origValue + 1);
+            var actualValue = (int)typeAcc.GetStaticField("_staticPrivateField");
             Assert.AreEqual(origValue + 1, actualValue);
 
-            objAcc.SetStaticFieldOrProperty("_staticPrivateField", origValue - 1);
-            actualValue = (int)objAcc.GetStaticFieldOrProperty("_staticPrivateField");
+            typeAcc.SetStaticFieldOrProperty("_staticPrivateField", origValue - 1);
+            actualValue = (int)typeAcc.GetStaticFieldOrProperty("_staticPrivateField");
             Assert.AreEqual(origValue - 1, actualValue);
         }
         [TestMethod]
         public void Accessor_Private_Type_Property()
         {
-            var objAcc = new TypeAccessor(typeof(AccessorTestObject));
+            var typeAcc = new TypeAccessor(typeof(AccessorTestObject));
 
-            var origValue = (int)objAcc.GetStaticProperty("StaticPrivateProperty");
-            objAcc.SetStaticProperty("StaticPrivateProperty", origValue + 1);
-            var actualValue = (int)objAcc.GetStaticProperty("StaticPrivateProperty");
+            var origValue = (int)typeAcc.GetStaticProperty("StaticPrivateProperty");
+            typeAcc.SetStaticProperty("StaticPrivateProperty", origValue + 1);
+            var actualValue = (int)typeAcc.GetStaticProperty("StaticPrivateProperty");
             Assert.AreEqual(origValue + 1, actualValue);
 
-            objAcc.SetStaticFieldOrProperty("StaticPrivateProperty", origValue - 1);
-            actualValue = (int)objAcc.GetStaticFieldOrProperty("StaticPrivateProperty");
+            typeAcc.SetStaticFieldOrProperty("StaticPrivateProperty", origValue - 1);
+            actualValue = (int)typeAcc.GetStaticFieldOrProperty("StaticPrivateProperty");
             Assert.AreEqual(origValue - 1, actualValue);
         }
         [TestMethod]
         public void Accessor_Private_Type_Method()
         {
-            var objAcc = new TypeAccessor(typeof(AccessorTestObject));
+            var typeAcc = new TypeAccessor(typeof(AccessorTestObject));
 
-            var actualValue = (string)objAcc.InvokeStatic("StaticPrivateMethod", '*', 5);
+            var actualValue = (string)typeAcc.InvokeStatic("StaticPrivateMethod", '*', 5);
             Assert.AreEqual("StaticPrivateMethod*****", actualValue);
 
-            actualValue = (string)objAcc.InvokeStatic("StaticPrivateMethod", 
+            actualValue = (string)typeAcc.InvokeStatic("StaticPrivateMethod", 
                 new[] {typeof(char), typeof(int)}, 
                 new object[]{'*', 3});
 
@@ -161,40 +161,40 @@ namespace SenseNet.Tools.Tests
         [TestMethod]
         public void Accessor_Private_Object_Field()
         {
-            var typeAcc = new ObjectAccessor(new AccessorTestObject());
+            var objAcc = new ObjectAccessor(new AccessorTestObject());
 
-            var origValue = (int)typeAcc.GetField("_instancePrivateField");
-            typeAcc.SetField("_instancePrivateField", origValue + 1);
-            var actualValue = (int)typeAcc.GetField("_instancePrivateField");
+            var origValue = (int)objAcc.GetField("_instancePrivateField");
+            objAcc.SetField("_instancePrivateField", origValue + 1);
+            var actualValue = (int)objAcc.GetField("_instancePrivateField");
             Assert.AreEqual(origValue + 1, actualValue);
 
-            typeAcc.SetFieldOrProperty("_instancePrivateField", origValue - 1);
-            actualValue = (int)typeAcc.GetFieldOrProperty("_instancePrivateField");
+            objAcc.SetFieldOrProperty("_instancePrivateField", origValue - 1);
+            actualValue = (int)objAcc.GetFieldOrProperty("_instancePrivateField");
             Assert.AreEqual(origValue - 1, actualValue);
         }
         [TestMethod]
         public void Accessor_Private_Object_Property()
         {
-            var typeAcc = new ObjectAccessor(new AccessorTestObject());
+            var objAcc = new ObjectAccessor(new AccessorTestObject());
 
-            var origValue = (int)typeAcc.GetProperty("InstancePrivateProperty");
-            typeAcc.SetProperty("InstancePrivateProperty", origValue + 1);
-            var actualValue = (int)typeAcc.GetProperty("InstancePrivateProperty");
+            var origValue = (int)objAcc.GetProperty("InstancePrivateProperty");
+            objAcc.SetProperty("InstancePrivateProperty", origValue + 1);
+            var actualValue = (int)objAcc.GetProperty("InstancePrivateProperty");
             Assert.AreEqual(origValue + 1, actualValue);
 
-            typeAcc.SetFieldOrProperty("InstancePrivateProperty", origValue - 1);
-            actualValue = (int)typeAcc.GetFieldOrProperty("InstancePrivateProperty");
+            objAcc.SetFieldOrProperty("InstancePrivateProperty", origValue - 1);
+            actualValue = (int)objAcc.GetFieldOrProperty("InstancePrivateProperty");
             Assert.AreEqual(origValue - 1, actualValue);
         }
         [TestMethod]
         public void Accessor_Private_Object_Method()
         {
-            var typeAcc = new ObjectAccessor(new AccessorTestObject());
+            var objAcc = new ObjectAccessor(new AccessorTestObject());
 
-            var actualValue = (string)typeAcc.Invoke("InstancePrivateMethod", '*', 5);
+            var actualValue = (string)objAcc.Invoke("InstancePrivateMethod", '*', 5);
             Assert.AreEqual("InstancePrivateMethod*****", actualValue);
 
-            actualValue = (string)typeAcc.Invoke("InstancePrivateMethod",
+            actualValue = (string)objAcc.Invoke("InstancePrivateMethod",
                 new[] { typeof(char), typeof(int) },
                 new object[] { '*', 3 });
 
@@ -206,40 +206,40 @@ namespace SenseNet.Tools.Tests
         [TestMethod]
         public void Accessor_Public_Type_Field()
         {
-            var objAcc = new TypeAccessor(typeof(AccessorTestObject));
+            var typeAcc = new TypeAccessor(typeof(AccessorTestObject));
 
-            var origValue = (int)objAcc.GetStaticField("_staticPublicField");
-            objAcc.SetStaticField("_staticPublicField", origValue + 1);
-            var actualValue = (int)objAcc.GetStaticField("_staticPublicField");
+            var origValue = (int)typeAcc.GetStaticField("_staticPublicField");
+            typeAcc.SetStaticField("_staticPublicField", origValue + 1);
+            var actualValue = (int)typeAcc.GetStaticField("_staticPublicField");
             Assert.AreEqual(origValue + 1, actualValue);
 
-            objAcc.SetStaticFieldOrProperty("_staticPublicField", origValue - 1);
-            actualValue = (int)objAcc.GetStaticFieldOrProperty("_staticPublicField");
+            typeAcc.SetStaticFieldOrProperty("_staticPublicField", origValue - 1);
+            actualValue = (int)typeAcc.GetStaticFieldOrProperty("_staticPublicField");
             Assert.AreEqual(origValue - 1, actualValue);
         }
         [TestMethod]
         public void Accessor_Public_Type_Property()
         {
-            var objAcc = new TypeAccessor(typeof(AccessorTestObject));
+            var typeAcc = new TypeAccessor(typeof(AccessorTestObject));
 
-            var origValue = (int)objAcc.GetStaticProperty("StaticPublicProperty");
-            objAcc.SetStaticProperty("StaticPublicProperty", origValue + 1);
-            var actualValue = (int)objAcc.GetStaticProperty("StaticPublicProperty");
+            var origValue = (int)typeAcc.GetStaticProperty("StaticPublicProperty");
+            typeAcc.SetStaticProperty("StaticPublicProperty", origValue + 1);
+            var actualValue = (int)typeAcc.GetStaticProperty("StaticPublicProperty");
             Assert.AreEqual(origValue + 1, actualValue);
 
-            objAcc.SetStaticFieldOrProperty("StaticPublicProperty", origValue - 1);
-            actualValue = (int)objAcc.GetStaticFieldOrProperty("StaticPublicProperty");
+            typeAcc.SetStaticFieldOrProperty("StaticPublicProperty", origValue - 1);
+            actualValue = (int)typeAcc.GetStaticFieldOrProperty("StaticPublicProperty");
             Assert.AreEqual(origValue - 1, actualValue);
         }
         [TestMethod]
         public void Accessor_Public_Type_Method()
         {
-            var objAcc = new TypeAccessor(typeof(AccessorTestObject));
+            var typeAcc = new TypeAccessor(typeof(AccessorTestObject));
 
-            var actualValue = (string)objAcc.InvokeStatic("StaticPublicMethod", '*', 5);
+            var actualValue = (string)typeAcc.InvokeStatic("StaticPublicMethod", '*', 5);
             Assert.AreEqual("StaticPublicMethod*****", actualValue);
 
-            actualValue = (string)objAcc.InvokeStatic("StaticPublicMethod",
+            actualValue = (string)typeAcc.InvokeStatic("StaticPublicMethod",
                 new[] { typeof(char), typeof(int) },
                 new object[] { '*', 3 });
 
@@ -268,40 +268,40 @@ namespace SenseNet.Tools.Tests
         [TestMethod]
         public void Accessor_Public_Object_Field()
         {
-            var typeAcc = new ObjectAccessor(new AccessorTestObject());
+            var objAcc = new ObjectAccessor(new AccessorTestObject());
 
-            var origValue = (int)typeAcc.GetField("_instancePublicField");
-            typeAcc.SetField("_instancePublicField", origValue + 1);
-            var actualValue = (int)typeAcc.GetField("_instancePublicField");
+            var origValue = (int)objAcc.GetField("_instancePublicField");
+            objAcc.SetField("_instancePublicField", origValue + 1);
+            var actualValue = (int)objAcc.GetField("_instancePublicField");
             Assert.AreEqual(origValue + 1, actualValue);
 
-            typeAcc.SetFieldOrProperty("_instancePublicField", origValue - 1);
-            actualValue = (int)typeAcc.GetFieldOrProperty("_instancePublicField");
+            objAcc.SetFieldOrProperty("_instancePublicField", origValue - 1);
+            actualValue = (int)objAcc.GetFieldOrProperty("_instancePublicField");
             Assert.AreEqual(origValue - 1, actualValue);
         }
         [TestMethod]
         public void Accessor_Public_Object_Property()
         {
-            var typeAcc = new ObjectAccessor(new AccessorTestObject());
+            var objAcc = new ObjectAccessor(new AccessorTestObject());
 
-            var origValue = (int)typeAcc.GetProperty("InstancePublicProperty");
-            typeAcc.SetProperty("InstancePublicProperty", origValue + 1);
-            var actualValue = (int)typeAcc.GetProperty("InstancePublicProperty");
+            var origValue = (int)objAcc.GetProperty("InstancePublicProperty");
+            objAcc.SetProperty("InstancePublicProperty", origValue + 1);
+            var actualValue = (int)objAcc.GetProperty("InstancePublicProperty");
             Assert.AreEqual(origValue + 1, actualValue);
 
-            typeAcc.SetFieldOrProperty("InstancePublicProperty", origValue - 1);
-            actualValue = (int)typeAcc.GetFieldOrProperty("InstancePublicProperty");
+            objAcc.SetFieldOrProperty("InstancePublicProperty", origValue - 1);
+            actualValue = (int)objAcc.GetFieldOrProperty("InstancePublicProperty");
             Assert.AreEqual(origValue - 1, actualValue);
         }
         [TestMethod]
         public void Accessor_Public_Object_Method()
         {
-            var typeAcc = new ObjectAccessor(new AccessorTestObject());
+            var objAcc = new ObjectAccessor(new AccessorTestObject());
 
-            var actualValue = (string)typeAcc.Invoke("InstancePublicMethod", '*', 5);
+            var actualValue = (string)objAcc.Invoke("InstancePublicMethod", '*', 5);
             Assert.AreEqual("InstancePublicMethod*****", actualValue);
 
-            actualValue = (string)typeAcc.Invoke("InstancePublicMethod",
+            actualValue = (string)objAcc.Invoke("InstancePublicMethod",
                 new[] { typeof(char), typeof(int) },
                 new object[] { '*', 3 });
 
@@ -343,12 +343,12 @@ namespace SenseNet.Tools.Tests
         [TestMethod]
         public void Accessor_Protected_Type_Method1_OnAbstract()
         {
-            var objAcc = new TypeAccessor(typeof(AbstractionForAccessorTest));
+            var typeAcc = new TypeAccessor(typeof(AbstractionForAccessorTest));
 
-            var actualValue = (string)objAcc.InvokeStatic("ProtectedStaticMethod1", '@', 7);
+            var actualValue = (string)typeAcc.InvokeStatic("ProtectedStaticMethod1", '@', 7);
             Assert.AreEqual("ProtectedStaticMethod1@@@@@@@", actualValue);
 
-            actualValue = (string)objAcc.InvokeStatic("ProtectedStaticMethod1",
+            actualValue = (string)typeAcc.InvokeStatic("ProtectedStaticMethod1",
                 new[] { typeof(char), typeof(int) },
                 new object[] { '*', 3 });
 
@@ -357,12 +357,12 @@ namespace SenseNet.Tools.Tests
         [TestMethod]
         public void Accessor_Protected_Type_Method1_OnImplementation()
         {
-            var objAcc = new TypeAccessor(typeof(AccessorTestObject));
+            var typeAcc = new TypeAccessor(typeof(AccessorTestObject));
 
-            var actualValue = (string)objAcc.InvokeStatic("ProtectedStaticMethod1", '@', 7);
+            var actualValue = (string)typeAcc.InvokeStatic("ProtectedStaticMethod1", '@', 7);
             Assert.AreEqual("ProtectedStaticMethod1@@@@@@@", actualValue);
 
-            actualValue = (string)objAcc.InvokeStatic("ProtectedStaticMethod1",
+            actualValue = (string)typeAcc.InvokeStatic("ProtectedStaticMethod1",
                 new[] { typeof(char), typeof(int) },
                 new object[] { '*', 3 });
 
@@ -371,12 +371,12 @@ namespace SenseNet.Tools.Tests
         [TestMethod]
         public void Accessor_Protected_Type_Method2_OnAbstract()
         {
-            var objAcc = new TypeAccessor(typeof(AbstractionForAccessorTest));
+            var typeAcc = new TypeAccessor(typeof(AbstractionForAccessorTest));
 
-            var actualValue = (string)objAcc.InvokeStatic("ProtectedStaticMethod2", '@', 7);
+            var actualValue = (string)typeAcc.InvokeStatic("ProtectedStaticMethod2", '@', 7);
             Assert.AreEqual("ProtectedStaticMethod2@@@@@@@", actualValue);
 
-            actualValue = (string)objAcc.InvokeStatic("ProtectedStaticMethod2",
+            actualValue = (string)typeAcc.InvokeStatic("ProtectedStaticMethod2",
                 new[] { typeof(char), typeof(int) },
                 new object[] { '*', 3 });
 
@@ -385,12 +385,12 @@ namespace SenseNet.Tools.Tests
         [TestMethod]
         public void Accessor_Protected_Type_Method2_OnImplementation()
         {
-            var objAcc = new TypeAccessor(typeof(AccessorTestObject));
+            var typeAcc = new TypeAccessor(typeof(AccessorTestObject));
 
-            var actualValue = (string)objAcc.InvokeStatic("ProtectedStaticMethod2", '@', 7);
+            var actualValue = (string)typeAcc.InvokeStatic("ProtectedStaticMethod2", '@', 7);
             Assert.AreEqual("ProtectedOverriddenStaticMethod2@@@@@@@", actualValue);
 
-            actualValue = (string)objAcc.InvokeStatic("ProtectedStaticMethod2",
+            actualValue = (string)typeAcc.InvokeStatic("ProtectedStaticMethod2",
                 new[] { typeof(char), typeof(int) },
                 new object[] { '*', 3 });
 
@@ -401,29 +401,29 @@ namespace SenseNet.Tools.Tests
         public void Accessor_Protected_Object_InheritedProperty_OnAbstract()
         {
             AbstractionForAccessorTest instance = new AccessorTestObject();
-            var typeAcc = new ObjectAccessor(instance);
+            var objAcc = new ObjectAccessor(instance);
 
-            var origValue = (int)typeAcc.GetProperty("ProtectedInheritedProperty");
-            typeAcc.SetProperty("ProtectedInheritedProperty", origValue + 1);
-            var actualValue = (int)typeAcc.GetProperty("ProtectedInheritedProperty");
+            var origValue = (int)objAcc.GetProperty("ProtectedInheritedProperty");
+            objAcc.SetProperty("ProtectedInheritedProperty", origValue + 1);
+            var actualValue = (int)objAcc.GetProperty("ProtectedInheritedProperty");
             Assert.AreEqual(origValue + 1, actualValue);
 
-            typeAcc.SetFieldOrProperty("ProtectedInheritedProperty", origValue - 1);
-            actualValue = (int)typeAcc.GetFieldOrProperty("ProtectedInheritedProperty");
+            objAcc.SetFieldOrProperty("ProtectedInheritedProperty", origValue - 1);
+            actualValue = (int)objAcc.GetFieldOrProperty("ProtectedInheritedProperty");
             Assert.AreEqual(origValue - 1, actualValue);
         }
         [TestMethod]
         public void Accessor_Protected_Object_InheritedProperty_OnImplementation()
         {
-            var typeAcc = new ObjectAccessor(new AccessorTestObject());
+            var objAcc = new ObjectAccessor(new AccessorTestObject());
 
-            var origValue = (int)typeAcc.GetProperty("ProtectedInheritedProperty");
-            typeAcc.SetProperty("ProtectedInheritedProperty", origValue + 1);
-            var actualValue = (int)typeAcc.GetProperty("ProtectedInheritedProperty");
+            var origValue = (int)objAcc.GetProperty("ProtectedInheritedProperty");
+            objAcc.SetProperty("ProtectedInheritedProperty", origValue + 1);
+            var actualValue = (int)objAcc.GetProperty("ProtectedInheritedProperty");
             Assert.AreEqual(origValue + 1, actualValue);
 
-            typeAcc.SetFieldOrProperty("ProtectedInheritedProperty", origValue - 1);
-            actualValue = (int)typeAcc.GetFieldOrProperty("ProtectedInheritedProperty");
+            objAcc.SetFieldOrProperty("ProtectedInheritedProperty", origValue - 1);
+            actualValue = (int)objAcc.GetFieldOrProperty("ProtectedInheritedProperty");
             Assert.AreEqual(origValue - 1, actualValue);
         }
 
@@ -431,12 +431,12 @@ namespace SenseNet.Tools.Tests
         public void Accessor_Protected_Object_InheritedAbstractMethod()
         {
             AbstractionForAccessorTest instance = new AccessorTestObject();
-            var typeAcc = new ObjectAccessor(instance);
+            var objAcc = new ObjectAccessor(instance);
 
-            var actualValue = (string)typeAcc.Invoke("ProtectedInheritedAbstractMethod", '*', 5);
+            var actualValue = (string)objAcc.Invoke("ProtectedInheritedAbstractMethod", '*', 5);
             Assert.AreEqual("ProtectedInheritedAbstractMethod*****", actualValue);
 
-            actualValue = (string)typeAcc.Invoke("ProtectedInheritedAbstractMethod",
+            actualValue = (string)objAcc.Invoke("ProtectedInheritedAbstractMethod",
                 new[] { typeof(char), typeof(int) },
                 new object[] { '*', 3 });
 
@@ -447,12 +447,12 @@ namespace SenseNet.Tools.Tests
         public void Accessor_Protected_Object_InheritedVirtualMethod_OnAbstract()
         {
             AbstractionForAccessorTest instance = new AccessorTestObject();
-            var typeAcc = new ObjectAccessor(instance);
+            var objAcc = new ObjectAccessor(instance);
 
-            var actualValue = (string)typeAcc.Invoke("ProtectedInheritedVirtualMethod", '*', 5);
+            var actualValue = (string)objAcc.Invoke("ProtectedInheritedVirtualMethod", '*', 5);
             Assert.AreEqual("ProtectedInheritedVirtualMethod***** abstract value", actualValue);
 
-            actualValue = (string)typeAcc.Invoke("ProtectedInheritedVirtualMethod",
+            actualValue = (string)objAcc.Invoke("ProtectedInheritedVirtualMethod",
                 new[] { typeof(char), typeof(int) },
                 new object[] { '*', 3 });
 
@@ -462,12 +462,12 @@ namespace SenseNet.Tools.Tests
         [TestMethod]
         public void Accessor_Protected_Object_InheritedVirtualMethod_OnImplementation()
         {
-            var typeAcc = new ObjectAccessor(new AccessorTestObject());
+            var objAcc = new ObjectAccessor(new AccessorTestObject());
 
-            var actualValue = (string)typeAcc.Invoke("ProtectedInheritedVirtualMethod", '*', 5);
+            var actualValue = (string)objAcc.Invoke("ProtectedInheritedVirtualMethod", '*', 5);
             Assert.AreEqual("ProtectedInheritedVirtualMethod***** abstract value", actualValue);
 
-            actualValue = (string)typeAcc.Invoke("ProtectedInheritedVirtualMethod",
+            actualValue = (string)objAcc.Invoke("ProtectedInheritedVirtualMethod",
                 new[] { typeof(char), typeof(int) },
                 new object[] { '*', 3 });
 

--- a/src/SenseNet.Tools.Tests/AccessorTests.cs
+++ b/src/SenseNet.Tools.Tests/AccessorTests.cs
@@ -5,14 +5,13 @@ using SenseNet.Testing;
 
 namespace SenseNet.Tools.Tests
 {
-    [TestClass]
-    public class AccessorTests
-    {
-        #region private class AccessorTestObjects
+    #region private class AccessorTestObjects
 
-        private abstract class AbstractionForAccessorTest
+        internal abstract class AbstractionForAccessorTest
         {
-            protected static int ProtectedStaticProperty { get; set; } = 42;
+            private int _privateFieldOnAbstract;
+
+            protected static int ProtectedStaticProperty { get; set; }
 
             protected static string ProtectedStaticMethod1(char c, int count)
             {
@@ -27,7 +26,7 @@ namespace SenseNet.Tools.Tests
             protected virtual string ProtectedInheritedVirtualMethod(char c, int count) { return "abstract value"; }
         }
 
-        private class AccessorTestObject : AbstractionForAccessorTest
+        internal class AccessorTestObject : AbstractionForAccessorTest
         {
             private static int _staticPrivateField;
             private static int StaticPrivateProperty { get; set; }
@@ -44,16 +43,19 @@ namespace SenseNet.Tools.Tests
             public AccessorTestObject()
             {
             }
+
             private AccessorTestObject(int field)
             {
                 _instancePrivateField = field;
                 _instancePublicField = field;
             }
-            private AccessorTestObject(int field, int property):this(field)
+
+            private AccessorTestObject(int field, int property) : this(field)
             {
                 InstancePrivateProperty = property;
                 InstancePublicProperty = property;
             }
+
             public AccessorTestObject(int field, int property, bool isPublic) : this(field, property)
             {
                 InstancePrivateProperty = property;
@@ -64,6 +66,7 @@ namespace SenseNet.Tools.Tests
             {
                 return "StaticPrivateMethod" + new string(c, count);
             }
+
             private string InstancePrivateMethod(char c, int count)
             {
                 return "InstancePrivateMethod" + new string(c, count);
@@ -73,6 +76,7 @@ namespace SenseNet.Tools.Tests
             {
                 return "StaticPublicMethod" + new string(c, count);
             }
+
             public string InstancePublicMethod(char c, int count)
             {
                 return "InstancePublicMethod" + new string(c, count);
@@ -82,18 +86,26 @@ namespace SenseNet.Tools.Tests
             {
                 return "ProtectedOverriddenStaticMethod2" + new string(c, count);
             }
+
             protected override int ProtectedInheritedProperty { get; set; }
+
             protected override string ProtectedInheritedAbstractMethod(char c, int count)
             {
                 return "ProtectedInheritedAbstractMethod" + new string(c, count);
             }
+
             protected override string ProtectedInheritedVirtualMethod(char c, int count)
             {
                 return $"ProtectedInheritedVirtualMethod{new string(c, count)} " +
                        $"{base.ProtectedInheritedVirtualMethod(c, count)}";
             }
         }
+
         #endregion
+
+    [TestClass]
+    public class AccessorTests
+    {
 
         /* =============================================== Access to private members */
 
@@ -311,6 +323,21 @@ namespace SenseNet.Tools.Tests
         /* ----------------------------------------------- Inheritance tests */
 
         [TestMethod]
+        public void Accessor_Private_Object_Field_OnImplementation()
+        {
+            var objAcc = new ObjectAccessor(new AccessorTestObject(), typeof(AbstractionForAccessorTest));
+
+            var origValue = (int)objAcc.GetField("_privateFieldOnAbstract");
+            objAcc.SetField("_privateFieldOnAbstract", origValue + 1);
+            var actualValue = (int)objAcc.GetField("_privateFieldOnAbstract");
+            Assert.AreEqual(origValue + 1, actualValue);
+
+            objAcc.SetFieldOrProperty("_privateFieldOnAbstract", origValue - 1);
+            actualValue = (int)objAcc.GetFieldOrProperty("_privateFieldOnAbstract");
+            Assert.AreEqual(origValue - 1, actualValue);
+        }
+
+        [TestMethod]
         public void Accessor_Protected_Type_Property_OnAbstract()
         {
             var typeAcc = new TypeAccessor(typeof(AbstractionForAccessorTest));
@@ -458,7 +485,6 @@ namespace SenseNet.Tools.Tests
 
             Assert.AreEqual("ProtectedInheritedVirtualMethod*** abstract value", actualValue);
         }
-
         [TestMethod]
         public void Accessor_Protected_Object_InheritedVirtualMethod_OnImplementation()
         {

--- a/src/SenseNet.Tools/SenseNet.Tools.csproj
+++ b/src/SenseNet.Tools/SenseNet.Tools.csproj
@@ -5,7 +5,7 @@
     <RootNamespace>SenseNet.Tools</RootNamespace>
     <AssemblyName>SenseNet.Tools</AssemblyName>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>3.2.4</Version>
+    <Version>3.2.4.1</Version>
     <Title>sensenet Tools</Title>
     <Authors>tusmester,kavics</Authors>
     <Company>Sense/Net Inc.</Company>

--- a/src/SenseNet.Tools/SenseNet.Tools.csproj
+++ b/src/SenseNet.Tools/SenseNet.Tools.csproj
@@ -5,7 +5,7 @@
     <RootNamespace>SenseNet.Tools</RootNamespace>
     <AssemblyName>SenseNet.Tools</AssemblyName>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>3.2.4.1</Version>
+    <Version>3.2.4</Version>
     <Title>sensenet Tools</Title>
     <Authors>tusmester,kavics</Authors>
     <Company>Sense/Net Inc.</Company>

--- a/src/SenseNet.Tools/Testing/ObjectAccessor.cs
+++ b/src/SenseNet.Tools/Testing/ObjectAccessor.cs
@@ -137,7 +137,8 @@ namespace SenseNet.Testing
         }
         private FieldInfo GetFieldInfo(string name, bool throwOnError = true)
         {
-            var field = _targetType.GetField(name, BindingFlags.GetField | BindingFlags.FlattenHierarchy | _publicFlags) ?? _targetType.GetField(name,BindingFlags.GetField | BindingFlags.FlattenHierarchy |  _privateFlags);
+            var field = _targetType.GetField(name, BindingFlags.GetField | _publicFlags) ??
+                        _targetType.GetField(name, BindingFlags.GetField | _privateFlags);
             if (field == null && throwOnError)
                 throw new ApplicationException("Field not found: " + name);
             return field;

--- a/src/SenseNet.Tools/Testing/ObjectAccessor.cs
+++ b/src/SenseNet.Tools/Testing/ObjectAccessor.cs
@@ -27,6 +27,18 @@ namespace SenseNet.Testing
             _targetType = Target.GetType();
         }
         /// <summary>
+        /// Initializes a <see cref="ObjectAccessor"/> instance that wraps the given target object.
+        /// Target object can be accessed by the given <paramref name="baseType"/> type.
+        /// Typical usage: access a field that defined on the abstract ancestor.
+        /// </summary>
+        /// <param name="target">Object to wrap.</param>
+        /// <param name="baseType">Accessor abstraction.</param>
+        public ObjectAccessor(object target, Type baseType)
+        {
+            Target = target;
+            _targetType = baseType;
+        }
+        /// <summary>
         /// Initializes a new instance of the <see cref="ObjectAccessor" /> class that wraps the
         /// newly created instance of the specified type.
         /// </summary>
@@ -125,7 +137,7 @@ namespace SenseNet.Testing
         }
         private FieldInfo GetFieldInfo(string name, bool throwOnError = true)
         {
-            var field = _targetType.GetField(name, _publicFlags) ?? _targetType.GetField(name, _privateFlags);
+            var field = _targetType.GetField(name, BindingFlags.GetField | BindingFlags.FlattenHierarchy | _publicFlags) ?? _targetType.GetField(name,BindingFlags.GetField | BindingFlags.FlattenHierarchy |  _privateFlags);
             if (field == null && throwOnError)
                 throw new ApplicationException("Field not found: " + name);
             return field;

--- a/src/SenseNet.Tools/Testing/TypeAccessor.cs
+++ b/src/SenseNet.Tools/Testing/TypeAccessor.cs
@@ -10,8 +10,8 @@ namespace SenseNet.Testing
     /// </summary>
     public class TypeAccessor
     {
-        private BindingFlags _publicFlags = BindingFlags.Static | BindingFlags.Public;
-        private BindingFlags _privateFlags = BindingFlags.Static | BindingFlags.NonPublic;
+        private BindingFlags _publicFlags = BindingFlags.Static | BindingFlags.Public | BindingFlags.FlattenHierarchy;
+        private BindingFlags _privateFlags = BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.FlattenHierarchy;
 
         /// <summary>
         /// Gets the target type.


### PR DESCRIPTION
### Issue-1
To access a non-public field of an abstract class needs a new constructor on the ObjectAccessor that allows differentiation of the object instance and its type. For example, access to the "_data" field of the Node needs the following lines:
```csharp
var accessor = new ObjectAccessor(testNode, typeof(Node));
accessor .SetField("_data", testValue);
```
### Issue-2
To access a static member of the inheritance chain, the BindingFlags.FlattenHirerchy flag need be used in reflection calls.