### PR TITLE
Add a generic ILogger implementation.

### DIFF
--- a/src/SenseNet.Tools.Tests/SenseNet.Tools.Tests.csproj
+++ b/src/SenseNet.Tools.Tests/SenseNet.Tools.Tests.csproj
@@ -55,6 +55,9 @@
     <Reference Include="Microsoft.Extensions.Configuration.Json, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Extensions.Configuration.Json.2.2.0\lib\netstandard2.0\Microsoft.Extensions.Configuration.Json.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=3.1.7.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.3.1.7\lib\netstandard2.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Extensions.FileProviders.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Extensions.FileProviders.Abstractions.2.2.0\lib\netstandard2.0\Microsoft.Extensions.FileProviders.Abstractions.dll</HintPath>
     </Reference>

--- a/src/SenseNet.Tools.Tests/SenseNet.Tools.Tests.csproj
+++ b/src/SenseNet.Tools.Tests/SenseNet.Tools.Tests.csproj
@@ -64,6 +64,9 @@
     <Reference Include="Microsoft.Extensions.FileSystemGlobbing, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Extensions.FileSystemGlobbing.2.2.0\lib\netstandard2.0\Microsoft.Extensions.FileSystemGlobbing.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.Extensions.Logging.Abstractions, Version=3.1.7.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Logging.Abstractions.3.1.7\lib\netstandard2.0\Microsoft.Extensions.Logging.Abstractions.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Extensions.Primitives, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Extensions.Primitives.2.2.0\lib\netstandard2.0\Microsoft.Extensions.Primitives.dll</HintPath>
     </Reference>
@@ -133,6 +136,7 @@
     <Compile Include="SnTraceTestClass.cs" />
     <Compile Include="SnTraceTests.cs" />
     <Compile Include="SnLogTests.cs" />
+    <Compile Include="TestILogger.cs" />
     <Compile Include="TypeResolverTests.cs" />
     <Compile Include="UtilityTests.cs" />
   </ItemGroup>

--- a/src/SenseNet.Tools.Tests/TestILogger.cs
+++ b/src/SenseNet.Tools.Tests/TestILogger.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.Logging;
+using EventId = Microsoft.Extensions.Logging.EventId;
+
+namespace SenseNet.Tools.Tests
+{
+    internal class LogEntry
+    {
+        internal LogLevel LogLevel { get; set; }
+        internal EventId EventId { get; set; }
+        internal string Message { get; set; }
+    }
+    internal class TestILogger<T> : ILogger<T>
+    {
+        public List<LogEntry> Entries { get; } = new List<LogEntry>();
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+        {
+            Entries.Add(new LogEntry
+            {
+                LogLevel = logLevel,
+                EventId = eventId,
+                Message = formatter?.Invoke(state, exception)
+            });
+        }
+
+        public bool IsEnabled(LogLevel logLevel)
+        {
+            return true;
+        }
+
+        public IDisposable BeginScope<TState>(TState state)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/SenseNet.Tools.Tests/packages.config
+++ b/src/SenseNet.Tools.Tests/packages.config
@@ -4,6 +4,7 @@
   <package id="Microsoft.Extensions.Configuration.Abstractions" version="2.2.0" targetFramework="net461" />
   <package id="Microsoft.Extensions.Configuration.FileExtensions" version="2.2.0" targetFramework="net461" />
   <package id="Microsoft.Extensions.Configuration.Json" version="2.2.0" targetFramework="net461" />
+  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="3.1.7" targetFramework="net461" />
   <package id="Microsoft.Extensions.FileProviders.Abstractions" version="2.2.0" targetFramework="net461" />
   <package id="Microsoft.Extensions.FileProviders.Physical" version="2.2.0" targetFramework="net461" />
   <package id="Microsoft.Extensions.FileSystemGlobbing" version="2.2.0" targetFramework="net461" />

--- a/src/SenseNet.Tools.Tests/packages.config
+++ b/src/SenseNet.Tools.Tests/packages.config
@@ -7,6 +7,7 @@
   <package id="Microsoft.Extensions.FileProviders.Abstractions" version="2.2.0" targetFramework="net461" />
   <package id="Microsoft.Extensions.FileProviders.Physical" version="2.2.0" targetFramework="net461" />
   <package id="Microsoft.Extensions.FileSystemGlobbing" version="2.2.0" targetFramework="net461" />
+  <package id="Microsoft.Extensions.Logging.Abstractions" version="3.1.7" targetFramework="net461" />
   <package id="Microsoft.Extensions.Primitives" version="2.2.0" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net461" />
   <package id="System.Buffers" version="4.4.0" targetFramework="net461" />

--- a/src/SenseNet.Tools/Diagnostics/LoggerExtensions.cs
+++ b/src/SenseNet.Tools/Diagnostics/LoggerExtensions.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using SenseNet.Diagnostics;
+
+// ReSharper disable once CheckNamespace
+namespace SenseNet.Extensions.DependencyInjection
+{
+    public static class LoggerExtensions
+    {
+        /// <summary>
+        /// Routes all log and trace messages to the official .Net ILogger interface.
+        /// </summary>
+        public static IServiceProvider AddSenseNetILogger(this IServiceProvider provider)
+        {
+            var iLogger = provider.GetService<ILogger<SnILogger>>();
+            if (iLogger != null)
+                SnLog.Instance = new SnILogger(iLogger);
+
+            var iTracer = provider.GetService<ILogger<SnILoggerTracer>>();
+            if (iTracer != null)
+                SnTrace.SnTracers.Add(new SnILoggerTracer(iTracer));
+
+            return provider;
+        }
+    }
+}

--- a/src/SenseNet.Tools/Diagnostics/SnILogger.cs
+++ b/src/SenseNet.Tools/Diagnostics/SnILogger.cs
@@ -2,12 +2,13 @@
 using System.Diagnostics;
 using Microsoft.Extensions.Logging;
 
+// ReSharper disable once CheckNamespace
 namespace SenseNet.Diagnostics
 {
     /// <summary>
     /// Routes all log messages to the official .Net log interface.
     /// </summary>
-    public class SnILogger : SnEventloggerBase
+    internal class SnILogger : SnEventloggerBase
     {
         private readonly ILogger<SnILogger> _logger;
         public SnILogger(ILogger<SnILogger> logger)

--- a/src/SenseNet.Tools/Diagnostics/SnILogger.cs
+++ b/src/SenseNet.Tools/Diagnostics/SnILogger.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Diagnostics;
+using Microsoft.Extensions.Logging;
+
+namespace SenseNet.Diagnostics
+{
+    /// <summary>
+    /// Routes all log messages to the official .Net log interface.
+    /// </summary>
+    public class SnILogger : SnEventloggerBase
+    {
+        private readonly ILogger<SnILogger> _logger;
+        public SnILogger(ILogger<SnILogger> logger)
+        {
+            _logger = logger;
+        }
+
+        protected override void WriteEntry(string entry, EventLogEntryType entryType, int eventId)
+        {
+            switch (entryType)
+            {
+                case EventLogEntryType.Error:
+                case EventLogEntryType.FailureAudit:
+                    _logger?.LogError(eventId, entry);
+                    break;
+                case EventLogEntryType.SuccessAudit:
+                case EventLogEntryType.Information:
+                    _logger?.LogInformation(eventId, entry);
+                    break;
+                case EventLogEntryType.Warning:
+                    _logger?.LogWarning(eventId, entry);
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(entryType), entryType, null);
+            }
+        }
+    }
+}

--- a/src/SenseNet.Tools/Diagnostics/SnILoggerTracer.cs
+++ b/src/SenseNet.Tools/Diagnostics/SnILoggerTracer.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.Extensions.Logging;
+
+namespace SenseNet.Diagnostics
+{
+    /// <summary>
+    /// Routes all trace messages to the official .Net log interface.
+    /// </summary>
+    public class SnILoggerTracer : ISnTracer
+    {
+        private readonly ILogger<SnILoggerTracer> _logger;
+        public SnILoggerTracer(ILogger<SnILoggerTracer> logger)
+        {
+            _logger = logger;
+        }
+
+        public void Write(string line)
+        {
+            _logger?.LogTrace(line);
+        }
+
+        public void Flush()
+        {
+            // do nothing
+        }
+    }
+}

--- a/src/SenseNet.Tools/Diagnostics/SnILoggerTracer.cs
+++ b/src/SenseNet.Tools/Diagnostics/SnILoggerTracer.cs
@@ -1,11 +1,12 @@
 ﻿using Microsoft.Extensions.Logging;
 
+// ReSharper disable once CheckNamespace
 namespace SenseNet.Diagnostics
 {
     /// <summary>
     /// Routes all trace messages to the official .Net log interface.
     /// </summary>
-    public class SnILoggerTracer : ISnTracer
+    internal class SnILoggerTracer : ISnTracer
     {
         private readonly ILogger<SnILoggerTracer> _logger;
         public SnILoggerTracer(ILogger<SnILoggerTracer> logger)

--- a/src/SenseNet.Tools/SenseNet.Tools.csproj
+++ b/src/SenseNet.Tools/SenseNet.Tools.csproj
@@ -31,6 +31,7 @@
   
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.7" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.7" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.5.0" />
     <PackageReference Include="System.Diagnostics.EventLog" Version="4.5.0" />

--- a/src/SenseNet.Tools/SenseNet.Tools.csproj
+++ b/src/SenseNet.Tools/SenseNet.Tools.csproj
@@ -31,6 +31,7 @@
   
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.7" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.5.0" />
     <PackageReference Include="System.Diagnostics.EventLog" Version="4.5.0" />
   </ItemGroup>


### PR DESCRIPTION
Web apps will be able to use these classes to route SnLog and SnTrace messages to the currently registered ILogger instance.