### PR TITLE
Add extension method for registering ILogger wrapper classes

### DIFF
--- a/src/SenseNet.Tools/Diagnostics/LoggerExtensions.cs
+++ b/src/SenseNet.Tools/Diagnostics/LoggerExtensions.cs
@@ -23,5 +23,16 @@ namespace SenseNet.Extensions.DependencyInjection
 
             return provider;
         }
+
+        /// <summary>
+        /// Register the logger and tracer wrapper classes for the ILogger interface.
+        /// </summary>
+        public static IServiceCollection AddSenseNetILogger(this IServiceCollection services)
+        {
+            services.AddSingleton<IEventLogger, SnILogger>();
+            services.AddSingleton<ISnTracer, SnILoggerTracer>();
+
+            return services;
+        }
     }
 }

--- a/src/SenseNet.Tools/Diagnostics/SnILogger.cs
+++ b/src/SenseNet.Tools/Diagnostics/SnILogger.cs
@@ -8,7 +8,7 @@ namespace SenseNet.Diagnostics
     /// <summary>
     /// Routes all log messages to the official .Net log interface.
     /// </summary>
-    internal class SnILogger : SnEventloggerBase
+    public class SnILogger : SnEventloggerBase
     {
         private readonly ILogger<SnILogger> _logger;
         public SnILogger(ILogger<SnILogger> logger)

--- a/src/SenseNet.Tools/Diagnostics/SnILoggerTracer.cs
+++ b/src/SenseNet.Tools/Diagnostics/SnILoggerTracer.cs
@@ -6,7 +6,7 @@ namespace SenseNet.Diagnostics
     /// <summary>
     /// Routes all trace messages to the official .Net log interface.
     /// </summary>
-    internal class SnILoggerTracer : ISnTracer
+    public class SnILoggerTracer : ISnTracer
     {
         private readonly ILogger<SnILoggerTracer> _logger;
         public SnILoggerTracer(ILogger<SnILoggerTracer> logger)


### PR DESCRIPTION
Add extension method for registering ILogger wrapper classes in the service collection. These instances can be used later by the application to set the logger and tracer instances 'back' to this component.