### PR TITLE
Use cancellation in async Retrier methods.

### DIFF
--- a/src/SenseNet.Tools/Tools/Retrier/DefaultRetrier.cs
+++ b/src/SenseNet.Tools/Tools/Retrier/DefaultRetrier.cs
@@ -106,7 +106,7 @@ namespace SenseNet.Tools
                     }
 
                     return true;
-                });
+                }, cancel);
         }
     }
 }


### PR DESCRIPTION
I added missing cancellation support to old async methods and also changed the waiting call from Thread.Sleep to the async Task.Delay.